### PR TITLE
fix webpack for headless

### DIFF
--- a/examples/react-headless/webpack.js
+++ b/examples/react-headless/webpack.js
@@ -12,6 +12,12 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.m?js$/,
+        resolve: {
+          fullySpecified: false, // disable the behaviour
+        },
+      },
+      {
         test: /\.(ts|js)x?$/i,
         exclude: /node_modules/,
         use: {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "clean:workspace": "yarn workspace @polkadot-onboard/core cache clean && yarn workspace @polkadot-onboard/injected-wallets cache clean && yarn workspace @polkadot-onboard/wallet-connect cache clean && yarn workspace @polkadot-onboard/react cache clean",
     "install:workspace": "yarn workspace @polkadot-onboard/core install && yarn workspace @polkadot-onboard/injected-wallets install && yarn workspace @polkadot-onboard/wallet-connect install && yarn workspace @polkadot-onboard/react install",
-    "build": "yarn workspace @polkadot-onboard/core build && yarn workspace @polkadot-onboard/injected-wallets build && yarn workspace @polkadot-onboard/wallet-connect build && yarn workspace @polkadot-onboard/react build",
+    "build:workspace": "yarn workspace @polkadot-onboard/core build && yarn workspace @polkadot-onboard/injected-wallets build && yarn workspace @polkadot-onboard/wallet-connect build && yarn workspace @polkadot-onboard/react build",
     "publish:core": "yarn workspace @polkadot-onboard/core npm publish --access public",
     "publish:injected-wallets": "yarn workspace @polkadot-onboard/injected-wallets npm publish --access public",
     "publish:wallet-connect": "yarn workspace @polkadot-onboard/wallet-connect npm publish --access public",

--- a/packages/core/src/lib/walletAggregator.ts
+++ b/packages/core/src/lib/walletAggregator.ts
@@ -1,4 +1,4 @@
-import { BaseWallet, BaseWalletProvider } from './types';
+import type { BaseWallet, BaseWalletProvider } from './types';
 
 export class WalletAggregator {
   walletProviders: BaseWalletProvider[];


### PR DESCRIPTION
Webpack should disable fullySpecified requirement, we might also consider importing all modules in the lib with `.js` extension in the typescript but not sure if that is the right thing.
This rule should work for webpack.