### PR TITLE
add initialWaitTime to react props

### DIFF
--- a/packages/react/src/contexts/PolkadotWalletsContext.tsx
+++ b/packages/react/src/contexts/PolkadotWalletsContext.tsx
@@ -5,6 +5,7 @@ import { createContext, useState, useMemo, useEffect, useContext } from 'react';
 interface PolkadotWalletsContextProviderProps {
   children: any;
   walletAggregator: WalletAggregator;
+  initialWaitMs?: number;
 }
 
 interface PolkadotWalletsContextProps {
@@ -17,11 +18,18 @@ const PolkadotWalletsContext = createContext<PolkadotWalletsContextProps>({
 
 export const useWallets = () => useContext(PolkadotWalletsContext);
 
-export const PolkadotWalletsContextProvider = ({ children, walletAggregator }: PolkadotWalletsContextProviderProps) => {
+export const PolkadotWalletsContextProvider = ({
+  children,
+  walletAggregator,
+  initialWaitMs = 5 /* the default is set to 5ms to give extensions enough lead time to inject their providers */,
+}: PolkadotWalletsContextProviderProps) => {
   const [wallets, setWallets] = useState<BaseWallet[] | undefined>();
 
   useEffect(() => {
-    setWallets(walletAggregator.getWallets());
+    const timeoutId = setTimeout(() => {
+      setWallets(walletAggregator.getWallets());
+    }, initialWaitMs);
+    return () => clearTimeout(timeoutId);
   }, [walletAggregator]);
 
   const contextData = useMemo(


### PR DESCRIPTION
Adds an initialWaitTime to props to let specify the lead time needed for wallets to inject their providers.
The default is set to 5ms which seems to be enough even for PK-JS which is usually slower than others.