### PR TITLE
Allow custom chainId in wallet-connect

### DIFF
--- a/packages/wallet-connect/src/signer.ts
+++ b/packages/wallet-connect/src/signer.ts
@@ -2,6 +2,7 @@ import type { HexString } from '@polkadot/util/types';
 import type { Signer, SignerResult } from '@polkadot/types/types';
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { SessionTypes } from '@walletconnect/types';
+import type { PolkadotNamespaceChainId } from './types';
 
 import { TypeRegistry } from '@polkadot/types';
 import SignClient from '@walletconnect/sign-client';
@@ -14,10 +15,10 @@ export class WalletConnectSigner implements Signer {
   registry: TypeRegistry;
   client: SignClient;
   session: SessionTypes.Struct;
-  chainId: string;
+  chainId: PolkadotNamespaceChainId;
   id = 0;
 
-  constructor(client: SignClient, session: SessionTypes.Struct, chainId: string) {
+  constructor(client: SignClient, session: SessionTypes.Struct, chainId: PolkadotNamespaceChainId) {
     this.client = client;
     this.session = session;
     this.registry = new TypeRegistry();
@@ -46,7 +47,7 @@ export class WalletConnectSigner implements Signer {
   signRaw = async (raw: SignerPayloadRaw): Promise<SignerResult> => {
     let request = {
       topic: this.session.topic,
-      chainId: 'polkadot:91b171bb158e2d3848fa23a9f1c25182',
+      chainId: this.chainId,
       request: {
         id: 1,
         jsonrpc: '2.0',

--- a/packages/wallet-connect/src/types.ts
+++ b/packages/wallet-connect/src/types.ts
@@ -1,4 +1,5 @@
 import { SignClientTypes } from '@walletconnect/types';
 
 export type WcAccount = `${string}:${string}:${string}`;
+export type PolkadotNamespaceChainId = `polkadot:${string}`;
 export interface WalletConnectConfiguration extends SignClientTypes.Options {}

--- a/packages/wallet-connect/src/wallet-connect.ts
+++ b/packages/wallet-connect/src/wallet-connect.ts
@@ -1,14 +1,14 @@
 import type { Account, BaseWallet, BaseWalletProvider, WalletMetadata } from '@polkadot-onboard/core';
 import type { Signer } from '@polkadot/types/types';
 import type { SessionTypes } from '@walletconnect/types';
-import type { WalletConnectConfiguration, WcAccount } from './types';
+import type { PolkadotNamespaceChainId, WalletConnectConfiguration, WcAccount } from './types';
 
 import { WalletType } from '@polkadot-onboard/core';
 import SignClient from '@walletconnect/sign-client';
 import QRCodeModal from '@walletconnect/qrcode-modal';
 import { WalletConnectSigner } from './signer';
 
-export const CHAIN_ID = 'polkadot:91b171bb158e2d3848fa23a9f1c25182';
+export const POLKADOT_CHAIN_ID = 'polkadot:91b171bb158e2d3848fa23a9f1c25182';
 export const WC_VERSION = '2.0';
 
 const toWalletAccount = (wcAccount: WcAccount) => {
@@ -24,8 +24,9 @@ class WalletConnectWallet implements BaseWallet {
   client: SignClient | undefined;
   signer: Signer | undefined;
   session: SessionTypes.Struct | undefined;
+  chainId: PolkadotNamespaceChainId;
 
-  constructor(config: WalletConnectConfiguration, appName: string) {
+  constructor(config: WalletConnectConfiguration, appName: string, chainId?: PolkadotNamespaceChainId) {
     this.config = config;
     this.appName = appName;
     this.metadata = {
@@ -36,6 +37,7 @@ class WalletConnectWallet implements BaseWallet {
       iconUrl: config.metadata?.icons[0] || '',
       version: WC_VERSION,
     };
+    this.chainId = chainId || POLKADOT_CHAIN_ID;
   }
 
   reset(): void {
@@ -65,7 +67,7 @@ class WalletConnectWallet implements BaseWallet {
       requiredNamespaces: {
         polkadot: {
           methods: ['polkadot_signTransaction', 'polkadot_signMessage'],
-          chains: [CHAIN_ID],
+          chains: [this.chainId],
           events: [],
         },
       },
@@ -85,7 +87,7 @@ class WalletConnectWallet implements BaseWallet {
           // setup the client
           this.client = client;
           this.session = session;
-          this.signer = new WalletConnectSigner(client, session, CHAIN_ID);
+          this.signer = new WalletConnectSigner(client, session, this.chainId);
           resolve();
         })
         .catch(reject)


### PR DESCRIPTION
This PR adds an optional `chainId` argument to the constructor of the `WalletConnectWallet` class, allowing for it to be set with any chain id within the Polkadot namespace (`polkadot:...`). If the argument is not used it defaults to the hardcoded Polkadot chain id, maintaining the original behavior.