### PR TITLE
Added optional chainId argument to WalletConnectProvider

### DIFF
--- a/packages/wallet-connect/src/signer.ts
+++ b/packages/wallet-connect/src/signer.ts
@@ -2,10 +2,11 @@ import type { HexString } from '@polkadot/util/types';
 import type { Signer, SignerResult } from '@polkadot/types/types';
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { SessionTypes } from '@walletconnect/types';
-import type { PolkadotNamespaceChainId } from './types.js';
 
 import { TypeRegistry } from '@polkadot/types';
 import SignClient from '@walletconnect/sign-client';
+
+import { POLKADOT_CHAIN_ID } from './wallet-connect';
 
 interface Signature {
   signature: HexString;
@@ -15,21 +16,19 @@ export class WalletConnectSigner implements Signer {
   registry: TypeRegistry;
   client: SignClient;
   session: SessionTypes.Struct;
-  chainId: PolkadotNamespaceChainId;
   id = 0;
 
-  constructor(client: SignClient, session: SessionTypes.Struct, chainId: PolkadotNamespaceChainId) {
+  constructor(client: SignClient, session: SessionTypes.Struct) {
     this.client = client;
     this.session = session;
     this.registry = new TypeRegistry();
-    this.chainId = chainId;
   }
 
   // this method is set this way to be bound to this class.
   signPayload = async (payload: SignerPayloadJSON): Promise<SignerResult> => {
     let request = {
       topic: this.session.topic,
-      chainId: this.chainId,
+      chainId: `polkadot:${payload.genesisHash.replace("0x", '').substring(0, 32)}`,
       request: {
         id: 1,
         jsonrpc: '2.0',
@@ -47,7 +46,7 @@ export class WalletConnectSigner implements Signer {
   signRaw = async (raw: SignerPayloadRaw): Promise<SignerResult> => {
     let request = {
       topic: this.session.topic,
-      chainId: this.chainId,
+      chainId: POLKADOT_CHAIN_ID,
       request: {
         id: 1,
         jsonrpc: '2.0',

--- a/packages/wallet-connect/src/types.ts
+++ b/packages/wallet-connect/src/types.ts
@@ -2,4 +2,6 @@ import { SignClientTypes } from '@walletconnect/types';
 
 export type WcAccount = `${string}:${string}:${string}`;
 export type PolkadotNamespaceChainId = `polkadot:${string}`;
-export interface WalletConnectConfiguration extends SignClientTypes.Options {}
+export interface WalletConnectConfiguration extends SignClientTypes.Options {
+    chainIds?: PolkadotNamespaceChainId[];
+}

--- a/packages/wallet-connect/src/wallet-connect.ts
+++ b/packages/wallet-connect/src/wallet-connect.ts
@@ -1,7 +1,7 @@
 import type { Account, BaseWallet, BaseWalletProvider, WalletMetadata } from '@polkadot-onboard/core';
 import type { Signer } from '@polkadot/types/types';
 import type { SessionTypes } from '@walletconnect/types';
-import type { PolkadotNamespaceChainId, WalletConnectConfiguration, WcAccount } from './types.js';
+import type { WalletConnectConfiguration, WcAccount } from './types.js';
 
 import { WalletType } from '@polkadot-onboard/core';
 import SignClient from '@walletconnect/sign-client';
@@ -24,9 +24,9 @@ class WalletConnectWallet implements BaseWallet {
   client: SignClient | undefined;
   signer: Signer | undefined;
   session: SessionTypes.Struct | undefined;
-  chainId: PolkadotNamespaceChainId;
 
-  constructor(config: WalletConnectConfiguration, appName: string, chainId?: PolkadotNamespaceChainId) {
+  constructor(config: WalletConnectConfiguration, appName: string) {
+    if (!config.chainIds || config.chainIds.length === 0) config.chainIds = [POLKADOT_CHAIN_ID];
     this.config = config;
     this.appName = appName;
     this.metadata = {
@@ -37,7 +37,6 @@ class WalletConnectWallet implements BaseWallet {
       iconUrl: config.metadata?.icons[0] || '',
       version: WC_VERSION,
     };
-    this.chainId = chainId || POLKADOT_CHAIN_ID;
   }
 
   reset(): void {
@@ -67,7 +66,7 @@ class WalletConnectWallet implements BaseWallet {
       requiredNamespaces: {
         polkadot: {
           methods: ['polkadot_signTransaction', 'polkadot_signMessage'],
-          chains: [this.chainId],
+          chains: this.config.chainIds,
           events: [],
         },
       },
@@ -87,7 +86,7 @@ class WalletConnectWallet implements BaseWallet {
           // setup the client
           this.client = client;
           this.session = session;
-          this.signer = new WalletConnectSigner(client, session, this.chainId);
+          this.signer = new WalletConnectSigner(client, session);
           resolve();
         })
         .catch(reject)
@@ -116,15 +115,13 @@ class WalletConnectWallet implements BaseWallet {
 export class WalletConnectProvider implements BaseWalletProvider {
   config: WalletConnectConfiguration;
   appName: string;
-  chainId?: PolkadotNamespaceChainId;
 
-  constructor(config: WalletConnectConfiguration, appName: string, chainId?: PolkadotNamespaceChainId) {
+  constructor(config: WalletConnectConfiguration, appName: string) {
     this.config = config;
     this.appName = appName;
-    this.chainId = chainId;
   }
 
   getWallets(): BaseWallet[] {
-    return [new WalletConnectWallet(this.config, this.appName, this.chainId)];
+    return [new WalletConnectWallet(this.config, this.appName)];
   }
 }


### PR DESCRIPTION
In PR #65 I added the optional chainId argument to `WalletConnectWallet`, however I forgot to also add it as an argument to the `WalletConnectProvider` constructor, which is the class that's actually publicly visible and internally initializes `WalletConnectWallet`, so this PR finishes what the previous one started and thus actually making it possible to pass a custom chainId.