### PR TITLE
feat: subscribe accounts

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,6 +28,8 @@ export interface WalletMetadata {
   version?: string;
 }
 
+export type UnsubscribeFn = () => void;
+
 export interface BaseWallet {
   metadata: WalletMetadata;
   type: WalletType;
@@ -37,4 +39,5 @@ export interface BaseWallet {
   disconnect: () => Promise<void>;
   isConnected: () => boolean;
   getAccounts: () => Promise<Account[]>;
+  subscribeAccounts: (cb: (accounts: Account[]) => void) => Promise<UnsubscribeFn>;
 }

--- a/packages/injected-wallets/src/injectedWallets.ts
+++ b/packages/injected-wallets/src/injectedWallets.ts
@@ -1,5 +1,5 @@
 import type { Injected, InjectedWindow, InjectedAccount } from '@polkadot/extension-inject/types';
-import type { Account, BaseWallet, BaseWalletProvider, WalletMetadata } from '@polkadot-onboard/core';
+import type { Account, BaseWallet, BaseWalletProvider, UnsubscribeFn, WalletMetadata } from '@polkadot-onboard/core';
 import type { Signer } from '@polkadot/types/types';
 import type { ExtensionConfiguration, WalletExtension } from './types.js';
 import { WalletType } from '@polkadot-onboard/core';
@@ -30,6 +30,16 @@ class InjectedWallet implements BaseWallet {
     let injectedAccounts = await this.injected?.accounts.get();
     let walletAccounts = injectedAccounts?.map((account) => toWalletAccount(account));
     return walletAccounts || [];
+  }
+
+  async subscribeAccounts(cb: (accounts: Account[]) => void): Promise<UnsubscribeFn> {
+    const subscription = await this.injected?.accounts.subscribe((accounts) => {
+      cb(accounts.map(toWalletAccount));
+    });
+
+    return () => {
+      subscription?.();
+    };
   }
 
   async connect() {


### PR DESCRIPTION
This PR introduces the `subscribeAccounts(cb)` method on wallet objects, providing dapps with an up to date list of accounts in case user changes connected accounts from the wallet.

I changed react-headless example to use this approach, not sure if that's something you want though.
Please let me know if you prefer me to undo those changes, or actually change anything else.