### PR TITLE
Passing Wallet Connect Modal configuration options

### DIFF
--- a/packages/wallet-connect/src/types.ts
+++ b/packages/wallet-connect/src/types.ts
@@ -30,5 +30,7 @@ export interface WalletConnectConfiguration extends SignClientTypes.Options {
     explorerExcludedWalletIds?: string[] | 'ALL';
     termsOfServiceUrl?: string;
     privacyPolicyUrl?: string;
+    themeMode?: 'dark' | 'light';
+    themeVariables?: Record<string, string>;
   };
 }

--- a/packages/wallet-connect/src/types.ts
+++ b/packages/wallet-connect/src/types.ts
@@ -4,6 +4,15 @@ export type WcAccount = `${string}:${string}:${string}`;
 
 export type PolkadotNamespaceChainId = `polkadot:${string}`;
 
+export interface WalletOptionsType {
+  id: string;
+  name: string;
+  links: {
+    native: string;
+    universal?: string;
+  };
+}
+
 export interface WalletConnectConfiguration extends SignClientTypes.Options {
   // ToDo: Remove ```projectId``` when the following issue is resolved:
   // https://github.com/WalletConnect/walletconnect-monorepo/pull/3435
@@ -11,4 +20,15 @@ export interface WalletConnectConfiguration extends SignClientTypes.Options {
   chainIds?: PolkadotNamespaceChainId[];
   optionalChainIds?: PolkadotNamespaceChainId[];
   onSessionDelete?: () => void;
+  options?: {
+    mobileWallets?: WalletOptionsType[];
+    desktopWallets?: WalletOptionsType[];
+    walletImages?: Record<string, string>;
+    enableAuthMode?: boolean;
+    enableExplorer?: boolean;
+    explorerRecommendedWalletIds?: string[] | 'NONE';
+    explorerExcludedWalletIds?: string[] | 'ALL';
+    termsOfServiceUrl?: string;
+    privacyPolicyUrl?: string;
+  };
 }

--- a/packages/wallet-connect/src/wallet-connect.ts
+++ b/packages/wallet-connect/src/wallet-connect.ts
@@ -42,6 +42,7 @@ class WalletConnectWallet implements BaseWallet {
     this.walletConnectModal = new WalletConnectModal({
       projectId: config.projectId,
       chains: config.chainIds,
+      ...config.options,
     });
   }
 


### PR DESCRIPTION
It would be great if we could pass other Wallet Connect Modal options like in the [Wallet Connect docs](https://docs.walletconnect.com/advanced/walletconnectmodal/options).

Lettme know what you think. 
Thank you.